### PR TITLE
Fixed #189, incorrect comparision

### DIFF
--- a/src/lab/exp8/quizresults.php
+++ b/src/lab/exp8/quizresults.php
@@ -30,7 +30,7 @@ if ($Q4==4)
 echo "4 ";
 $total=$total+1;
 }
-if ((strcasecmp($Q5,"itself")==0)){
+if ((strcasecmp($Q5,"first")==0)){
 $total= $total+1;
 echo "5 ";
 }


### PR DESCRIPTION
As per given correct answers, q5 should take "first" as correct answer, the code accepts "itself" as the correct answer, fixed it.