### PR TITLE
Fitted output within borders

### DIFF
--- a/src/lab/exp1/simulation/numericalApproximation.css
+++ b/src/lab/exp1/simulation/numericalApproximation.css
@@ -861,7 +861,7 @@ body{
         position: static;
         top: 9%;
         width: 100%;
-        height: 70%;
+        height: 65%;
         text-align: center;
         /*font-size: 1em;*/
         font-size: 1.5vmin;


### PR DESCRIPTION
refering to issue: #485 
I was able to fit the "local Variables" and "Output" within the display of results by the reducing the height of class : "resultDisplay" from 70% to 65%. This didn't effect the view of any other components